### PR TITLE
Add dependabot updates for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      "GitHub Actions updates":
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      "Go modules updates":
+        dependency-type: "production"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: test
       run: |
-        go test -v -mod=vendor -timeout=60s -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
+        go test -v -timeout=60s -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
         cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "mock_" > $GITHUB_WORKSPACE/profile.cov
       working-directory: app
       env:
@@ -33,7 +33,7 @@ jobs:
       run: go install github.com/mattn/goveralls@latest
 
     - name: build
-      run: go build -v -mod=vendor
+      run: go build -v
       working-directory: app
 
     - name: submit coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ARG GIT_BRANCH
 ARG SKIP_TEST
 ARG GITHUB_SHA
 
-ENV GOFLAGS="-mod=vendor"
-
 ADD . /build/secrets
 WORKDIR /build/secrets
 
@@ -28,6 +26,9 @@ RUN \
 
 
 FROM umputun/baseimage:app-latest
+
+# enables automatic changelog generation by tools like Dependabot
+LABEL org.opencontainers.image.source="https://github.com/umputun/secrets"
 
 COPY --from=build-backend /build/secrets.bin /srv/secrets
 COPY --from=build-backend /build/secrets/ui/static /srv/ui/static/


### PR DESCRIPTION
There is no need for docker updates as the latest versions of containers are used.